### PR TITLE
feat: Update Click dependency version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "Werkzeug==3.1.3",
   "pydantic~=2.11.7",
   "jsonschema (>=4.24.0,<5.0.0)",
-  "Click~=8.2.0",
+  "Click>=8.1.8,<9"
 ]
 dynamic = ["version"]
 license = "MIT"


### PR DESCRIPTION
semgrep and few other dependencies on press, is dependent on click~=8.1.8.

In mcp server we are using basic methods from click. So, allowing it to use 8.1.x click versions also. Else, it's getting stuck at dependency resolution.